### PR TITLE
`RunScript(script, echo)` is not printing

### DIFF
--- a/.github/workflows/ghuserbuild.yml
+++ b/.github/workflows/ghuserbuild.yml
@@ -26,7 +26,7 @@ jobs:
           source: GH\PyGH\components
           target: GH\PyGH\build
       
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: ghuser-components
           path: GH\PyGH\build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -105,7 +105,7 @@ jobs:
       run: invoke yakerize
   
     - name: Save artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: scriptsync_yak_package
         path: yaker\build\*.yak
@@ -121,7 +121,7 @@ jobs:
         ref: main
 
     - name: Download artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: scriptsync_yak_package
         path: yaker\build
@@ -191,7 +191,7 @@ jobs:
         vsce package
 
     - name: Save artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: script-sync-vsix
         path: VSCode/scriptsync/*.vsix
@@ -232,7 +232,7 @@ jobs:
         npm install @types/mocha --save-dev
 
     - name: Download artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: script-sync-vsix
         path: VSCode\scriptsync
@@ -261,13 +261,13 @@ jobs:
         ref: main
 
     - name: Download Yak artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: scriptsync_yak_package
         path: yaker/build
 
     - name: Download VSIX artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: script-sync-vsix
         path: VSCode/scriptsync

--- a/.github/workflows/rhinoplugin.yml
+++ b/.github/workflows/rhinoplugin.yml
@@ -26,7 +26,7 @@ jobs:
       run: dotnet build ./CsRhino/ScriptSync.csproj --configuration Release --no-restore
 
     - name: Save artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ScriptSync.rhp
         path: ./CsRhino/bin/Release/net48/

--- a/.github/workflows/vscodeext.yml
+++ b/.github/workflows/vscodeext.yml
@@ -42,7 +42,7 @@ jobs:
         vsce package
 
     - name: Save artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: script-sync
         path: VSCode/scriptsync/*.vsix

--- a/.github/workflows/yakbuild.yml
+++ b/.github/workflows/yakbuild.yml
@@ -36,7 +36,7 @@ jobs:
       run: invoke yakerize
 
     - name: Save artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: scriptsync_yak_package
         path: yaker/build/*.yak

--- a/CsRhino/ScriptSyncStart.cs
+++ b/CsRhino/ScriptSyncStart.cs
@@ -113,6 +113,7 @@ namespace ScriptSync
                 {
                     try
                     {
+                        RhinoApp.WriteLine("ScriptSync Running: " + scriptPath);
                         RhinoApp.RunScript("_-ScriptEditor Run " + scriptPath, true);
                     }
                     catch (Exception e)


### PR DESCRIPTION
This PR solves #40 .
The problem is that the `_-ScriptEditor Run F:\script-sync\temp\testrh.py` (run through `RunScript()` [RhinoCommonAPI docu](https://mcneel-apidocs.herokuapp.com/api/rhinocommon/rhino.rhinoapp/runscript)) in `ScriptSyncStart.cs` Rhino is not recognizing anymore the `print()` in any python files are not recognized hence not printed in the Rhino terminal.

This seems to be a bug from Rhino side. This PR tries to find another method.